### PR TITLE
Correct filename case in #include directive

### DIFF
--- a/src/SpeedyStepper.h
+++ b/src/SpeedyStepper.h
@@ -34,7 +34,7 @@
 #ifndef SpeedyStepper_h
 #define SpeedyStepper_h
 
-#include <arduino.h>
+#include <Arduino.h>
 #include <stdlib.h>
 
 


### PR DESCRIPTION
Incorrect capitalization of Arduino.h causes compilation to fail on filename case-sensitive operating systems like Linux.