### PR TITLE
Update library.properties to version 1.0.1 to make Arduino IDEs use t…

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=SpeedyStepper
-version=1.0.0
+version=1.0.1
 author=S. Reifel
 license=MIT
 maintainer=S. Reifel <swr.reifel@gmail>


### PR DESCRIPTION
…he recent changes

The Arduino IDEs are using the 1.0.0 release from 6 years ago and before the https://github.com/Stan-Reifel/SpeedyStepper/commit/89e4b960792956fbe33a6141b8dabb352ca33e88 commit.

https://github.com/Stan-Reifel/SpeedyStepper/releases

With the old release as the most recent release, anyone who install this library from the IDE will get the old, broken "`#include <arduino.h>`" version.

Please update the library properties and then issue a new release with a matching version number.

Also, please turn on Settings/Issues.